### PR TITLE
Pass webpack extensions config to resolver

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ function resolveWebpackPath(partial, filename, directory, webpackConfig) {
     // We don't care about what the loader resolves the partial to
     // we only wnat the path of the resolved file
     partial = stripLoader(partial);
-    var resolvedPath = resolver(directory, partial);
+    var resolvedPath = resolver(path.dirname(filename), partial);
 
     return resolvedPath;
 

--- a/index.js
+++ b/index.js
@@ -185,11 +185,17 @@ function resolveWebpackPath(partial, filename, directory, webpackConfig) {
 
   try {
     var loadedConfig = require(webpackConfig);
-    var aliases = loadedConfig.resolve ? loadedConfig.resolve.alias : [];
+    var config = {
+      alias: [],
+    };
+    if (loadedConfig.resolve) {
+      config = {
+        alias: loadedConfig.resolve.alias,
+        extensions: loadedConfig.resolve.extensions,
+      };
+    }
 
-    var resolver = webpackResolve.create.sync({
-      alias: aliases
-    });
+    var resolver = webpackResolve.create.sync(config);
 
     // We don't care about what the loader resolves the partial to
     // we only wnat the path of the resolved file


### PR DESCRIPTION
If your webpack config has extensions in it other than "js", for
example, "jsx", they would be ignored by filing cabinet, causing
resolution failures.

This change passes the resolve.extensions config from webpack through to
the resolver.

Not sure what the best way to test this is without monkeying around with the webpack config.
