### PR TITLE
Support webpack resolve.root and resolve.modulesDirectories

### DIFF
--- a/test/root1/mod1.js
+++ b/test/root1/mod1.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/root2/mod2.js
+++ b/test/root2/mod2.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/test.js
+++ b/test/test.js
@@ -480,6 +480,39 @@ describe('filing-cabinet', function() {
       assert.equal(resolved, `${directory}/node_modules/resolve/index.js`);
     });
 
+    it('resolves a path using resolve.root', function() {
+      const resolved = cabinet({
+        partial: 'mod1',
+        filename: `${directory}/index.js`,
+        directory,
+        webpackConfig: `${directory}/webpack-root.config.js`
+      });
+
+      assert.equal(resolved, `${directory}/test/root1/mod1.js`);
+    });
+
+    it('resolves NPM module when using resolve.root', function() {
+      const resolved = cabinet({
+        partial: 'resolve',
+        filename: `${directory}/index.js`,
+        directory,
+        webpackConfig: `${directory}/webpack-root.config.js`
+      });
+
+      assert.equal(resolved, `${directory}/node_modules/resolve/index.js`);
+    });
+
+    it('resolves a path using resolve.modulesDirectories', function() {
+      const resolved = cabinet({
+        partial: 'mod2',
+        filename: `${directory}/index.js`,
+        directory,
+        webpackConfig: `${directory}/webpack-root.config.js`
+      });
+
+      assert.equal(resolved, `${directory}/test/root2/mod2.js`);
+    });
+
     it('resolves files with a .jsx extension', function() {
       testResolution('./test/foo.jsx', `${directory}/test/foo.jsx`);
     });

--- a/webpack-root.config.js
+++ b/webpack-root.config.js
@@ -1,0 +1,11 @@
+var path = require('path');
+
+module.exports = {
+  entry: "./index.js",
+  resolve: {
+    modulesDirectories: ['test/root1'],
+    root: [
+        path.resolve(__dirname, './test/root2')
+    ]
+  }
+};


### PR DESCRIPTION
This will add support for resolving paths using the [resolve.root](http://webpack.github.io/docs/configuration.html#resolve-root) option. This was needed by a project I was running madge on that was setup [like this example](http://moduscreate.com/es6-es2015-import-no-relative-path-webpack/). The default for [enhanced-resolve](https://github.com/webpack/enhanced-resolve) is to resolve from `node_modules` so this PR will make paths in `resolve.root` overwriting that.



