### PR TITLE
Handle resolve.modules supported by webpack2

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,9 +192,9 @@ function resolveWebpackPath(partial, filename, directory, webpackConfig) {
     return '';
   }
 
-  try {
-    var resolveConfig = objectAssign({}, loadedConfig.resolve);
+  var resolveConfig = objectAssign({}, loadedConfig.resolve);
 
+  if (!resolveConfig.modules && (resolveConfig.root || resolveConfig.modulesDirectories)) {
     resolveConfig.modules = [];
 
     if (resolveConfig.root) {
@@ -204,15 +204,9 @@ function resolveWebpackPath(partial, filename, directory, webpackConfig) {
     if (resolveConfig.modulesDirectories) {
       resolveConfig.modules = resolveConfig.modules.concat(resolveConfig.modulesDirectories);
     }
+  }
 
-    var foundNodeModulesInPaths = resolveConfig.modules.some(function(dir) {
-      return dir.match('node_modules');
-    });
-
-    if (!foundNodeModulesInPaths) {
-      resolveConfig.modules.push('node_modules');
-    }
-
+  try {
     var resolver = webpackResolve.create.sync(resolveConfig);
 
     // We don't care about what the loader resolves the partial to

--- a/test/test.js
+++ b/test/test.js
@@ -502,6 +502,17 @@ describe('filing-cabinet', function() {
       assert.equal(resolved, `${directory}/node_modules/resolve/index.js`);
     });
 
+    it('resolves NPM module when using resolve.modulesDirectories', function() {
+      const resolved = cabinet({
+        partial: 'resolve',
+        filename: `${directory}/index.js`,
+        directory,
+        webpackConfig: `${directory}/webpack-root.config.js`
+      });
+
+      assert.equal(resolved, `${directory}/node_modules/resolve/index.js`);
+    });
+
     it('resolves a path using resolve.modulesDirectories', function() {
       const resolved = cabinet({
         partial: 'mod2',

--- a/webpack-root.config.js
+++ b/webpack-root.config.js
@@ -3,9 +3,10 @@ var path = require('path');
 module.exports = {
   entry: "./index.js",
   resolve: {
-    modulesDirectories: ['test/root1'],
+    modulesDirectories: ['test/root1', 'node_modules'],
     root: [
-        path.resolve(__dirname, './test/root2')
+        path.resolve(__dirname, './test/root2'),
+        path.resolve(__dirname, './node_modules')
     ]
   }
 };


### PR DESCRIPTION
Sorry for spamming you with PR's ;) But I realised that `resolve.modules` is actually supported by [webpack2](https://webpack.js.org/configuration/resolve/#resolve-modules) so we need to handle that. I also took the opportunity to fix the things you mentioned in the last PR. So it will no longer overwrite the config if `resolve.modules` is used and it will not add `node_modules` automatically.

