### PR TITLE
Support webpack config that exports a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,6 +187,10 @@ function resolveWebpackPath(partial, filename, directory, webpackConfig) {
 
   try {
     var loadedConfig = require(webpackConfig);
+
+    if (typeof loadedConfig === 'function') {
+      loadedConfig = loadedConfig();
+    }
   } catch (e) {
     debug('error loading the webpack config at ' + webpackConfig);
     debug(e.message);

--- a/test/test.js
+++ b/test/test.js
@@ -562,6 +562,17 @@ describe('filing-cabinet', function() {
       assert.equal(resolved, `${directory}/test/root2/mod2.js`);
     });
 
+    it('resolves a path using webpack config that exports a function', function() {
+      const resolved = cabinet({
+        partial: 'R',
+        filename: `${directory}/index.js`,
+        directory,
+        webpackConfig: `${directory}/webpack-env.config.js`
+      });
+
+      assert.equal(resolved, `${directory}/node_modules/resolve/index.js`);
+    });
+
     it('resolves files with a .jsx extension', function() {
       testResolution('./test/foo.jsx', `${directory}/test/foo.jsx`);
     });

--- a/webpack-env.config.js
+++ b/webpack-env.config.js
@@ -1,0 +1,10 @@
+module.exports = function() {
+    return {
+      entry: "./index.js",
+      resolve: {
+        alias: {
+          R: './node_modules/resolve'
+        }
+      }
+    };
+};


### PR DESCRIPTION
Long time no see! :) 

This adds support for webpack config intended to be used with the `--env` option. See https://webpack.js.org/configuration/configuration-types/#exporting-a-function-to-use-env