### PR TITLE
chore: upgrade to is-relative-path 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2092,9 +2092,9 @@
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-relative-path": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-1.0.2.tgz",
-      "integrity": "sha1-CRtGoNZ8HtD+hfH4z93gBrslHUY="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-2.0.0.tgz",
+      "integrity": "sha1-vNCtPsI6STinfzQD0tv/NLmR+y8="
     },
     "is-utf8": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "commander": "^2.13.0",
     "debug": "^3.1.0",
     "enhanced-resolve": "^3.4.1",
-    "is-relative-path": "^1.0.2",
+    "is-relative-path": "^2.0.0",
     "module-definition": "^2.2.4",
     "module-lookup-amd": "^5.0.0",
     "resolve": "^1.5.0",


### PR DESCRIPTION
Upgrading is-relative-path from 1.0.2 to 2.0.0. 
```json
    "is-relative-path": "^2.0.0",
```

But the test run fails though: 
```console
  42 passing (168ms)
  1 failing
  1) filing-cabinet
       webpack
         resolves an absolute path from a file within a subdirectory:

      AssertionError [ERR_ASSERTION]: '' == '/../node-filing-cabinet/node_modules/resolve/index.js'
      + expected - actual

      +/../node-filing-cabinet/node_modules/resolve/index.js
      
      at Context.<anonymous> (test/test.js:595:14)
```
Let me know pointers if any towards resolving them. ( either at is-relative-path or in this project ) 



