### PR TITLE
Format TypeScript compilerOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ function tsLookup({dependency, filename, tsConfig}) {
   debug('processed typescript config: ', tsConfig);
   debug('processed typescript config type: ', typeof tsConfig);
 
-  const options = tsConfig.compilerOptions;
+  const {options} = ts.convertCompilerOptionsFromJson(tsConfig.compilerOptions);
 
   // Preserve for backcompat. Consider removing this as a breaking change.
   if (!options.module) {

--- a/test/mockedJSFiles.js
+++ b/test/mockedJSFiles.js
@@ -13,7 +13,11 @@ module.exports = {
       'index.ts': 'import foo from "./foo";',
       'module.tsx': 'import Foo from "./foo"; <Foo />;',
       'foo.ts': 'export default 1;',
-      '.tsconfig': '{ "version": "1.0.0", "compilerOptions": { "module": "commonjs" } }'
+      'check-nested.ts': 'import {Child} from "./subdir";',
+      '.tsconfig': '{ "version": "1.0.0", "compilerOptions": { "module": "commonjs" } }',
+      'subdir': {
+        'index.tsx': 'export Child = () => { return (<div></div>); );'
+      },
     },
     'amd': {
       'foo.js': 'define(["./bar"], function(bar){ return bar; });',


### PR DESCRIPTION
CompilerOptions from a tsconfig need to be preformatted before being
passed into `convertCompilerOptionsFromJson` otherwise you get crashes
when you try and specify an explicit value for `moduleResolution` in your tsconfig.

---

This helps solve https://github.com/pahen/madge/issues/128. I found this while trying to use madge / depdendency-tree in a repo that has many imports that look like "./components" which should resolve to the file "./components/index.ts" but those dependencies were not found. I added the path to my tsconfig (which contains `moduleResolution: "node"`) and then I started getting crashes.

It turns out `convertCompilerOptionsFromJson` expects enum values for `moduleResolution` and `module` (and possibly some others) - not the values direct from the tsconfig file. This PR calls the function that transforms the json values into the enum values.

While I was in there I found a way to shorten some of the Typescript mocking, so we only mock the one function that is needed, which makes for slightly more robust tests.