### PR TITLE
Report non-typescript imports within typescript files

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,9 +219,20 @@ function tsLookup({dependency, filename, tsConfig}) {
 
   const host = ts.createCompilerHost({});
   debug('with options: ', options);
-  const resolvedModule = ts.resolveModuleName(dependency, filename, options, host).resolvedModule;
-  debug('ts resolved module: ', resolvedModule);
-  const result = resolvedModule ? resolvedModule.resolvedFileName : '';
+
+  const namedModule = ts.resolveModuleName(dependency, filename, options, host);
+  let result = '';
+
+  if (namedModule.resolvedModule) {
+    result = namedModule.resolvedModule.resolvedFileName;
+  } else {
+    const suffix = '.d.ts';
+    const lookUpLocations = namedModule.failedLookupLocations
+      .filter((string) => string.endsWith(suffix))
+      .map((string) => string.substr(0, string.length - suffix.length));
+
+    result = lookUpLocations.find(ts.sys.fileExists) || '';
+  }
 
   debug('result: ' + result);
   return result ? path.resolve(result) : '';

--- a/test/mockedJSFiles.js
+++ b/test/mockedJSFiles.js
@@ -14,10 +14,12 @@ module.exports = {
       'module.tsx': 'import Foo from "./foo"; <Foo />;',
       'foo.ts': 'export default 1;',
       'check-nested.ts': 'import {Child} from "./subdir";',
+      'image.svg': '<svg></svg>',
       '.tsconfig': '{ "version": "1.0.0", "compilerOptions": { "module": "commonjs" } }',
       'subdir': {
-        'index.tsx': 'export Child = () => { return (<div></div>); );'
-      },
+        'index.tsx': 'export Child = () => { return (<div></div>); );',
+        'subimage.svg': '<svg></svg>'
+      }
     },
     'amd': {
       'foo.js': 'define(["./bar"], function(bar){ return bar; });',
@@ -38,6 +40,9 @@ module.exports = {
       }
     },
     'node_modules': {
+      'image': {
+        'npm-image.svg': '<svg></svg>'
+      },
       'lodash.assign': {
         'index.js': 'module.exports = function() {};'
       },

--- a/test/test.js
+++ b/test/test.js
@@ -455,6 +455,63 @@ describe('filing-cabinet', function() {
               path.join(path.resolve(directory), '/subdir/index.tsx')
             );
           });
+
+          it('finds imports of non-typescript files', function() {
+            const filename = directory + '/index.ts';
+
+            const result = cabinet({
+              partial: './image.svg',
+              filename,
+              directory
+            });
+
+            assert.equal(
+              result,
+              path.join(path.resolve(directory), '/image.svg')
+            );
+          });
+
+          it('finds imports of non-typescript files using custom import paths', function() {
+            const filename = directory + '/index.ts';
+
+            const result = cabinet({
+              partial: '@shortcut/subimage.svg',
+              filename,
+              directory,
+              tsConfig: {
+                compilerOptions: {
+                  moduleResolution: 'node',
+                  baseUrl: directory,
+                  paths: {
+                    '@shortcut/*': ['subdir/*'],
+                  }
+                }
+              }
+            });
+
+            assert.equal(
+              result,
+              path.join(path.resolve(directory), '/subdir/subimage.svg')
+            );
+          });
+
+          it('finds imports of non-typescript files from node_modules', function() {
+            const filename = directory + '/index.ts';
+
+            const result = cabinet({
+              partial: 'image/npm-image.svg',
+              filename,
+              directory,
+              tsConfig: {
+                compilerOptions: {moduleResolution: 'node'}
+              }
+            });
+
+            assert.equal(
+              result,
+              path.join(path.resolve(directory), '../node_modules/image/npm-image.svg')
+            );
+          });
         });
 
         describe('as a string', function() {


### PR DESCRIPTION
This make sure imports like `./foo.svg` within ts/tsx files are reported
correctly.

Fixes #76.
