### PR TITLE
Correctly resolve paths on Windows by updating resolve dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1881,9 +1881,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
-      "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "requires": {
         "path-parse": "^1.0.6"
       }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "is-relative-path": "^1.0.2",
     "module-definition": "^3.0.0",
     "module-lookup-amd": "^6.1.0",
-    "resolve": "^1.9.0",
+    "resolve": "^1.11.1",
     "resolve-dependency-path": "^2.0.0",
     "sass-lookup": "^3.0.0",
     "stylus-lookup": "^3.0.1",


### PR DESCRIPTION
This fixes an issue where dependency's would not be resolved on Windows.

See https://github.com/browserify/resolve/pull/156#issuecomment-496543642