### PR TITLE
Allow multiple default lookups for projects with JS and TS

### DIFF
--- a/test/mockedJSFiles.js
+++ b/test/mockedJSFiles.js
@@ -14,6 +14,7 @@ module.exports = {
       'index.ts': 'import foo from "./foo";',
       'module.tsx': 'import Foo from "./foo"; <Foo />;',
       'foo.ts': 'export default 1;',
+      'bar.js': 'import foo from "./foo";',
       'check-nested.ts': 'import {Child} from "./subdir";',
       'image.svg': '<svg></svg>',
       '.tsconfig': '{ "version": "1.0.0", "compilerOptions": { "module": "commonjs" }\n // comments\n }',

--- a/test/test.js
+++ b/test/test.js
@@ -601,6 +601,22 @@ describe('filing-cabinet', function() {
               path.join(path.resolve(directory), '../node_modules/image/npm-image.svg')
             );
           });
+
+          it('finds imports of typescript files from non-typescript files with allowJs option (#89)', function() {
+            const filename = directory + '/bar.js';
+            const result = cabinet({
+              partial: './foo',
+              filename,
+              directory,
+              tsConfig: {
+                compilerOptions: {allowJs: true}
+              }
+            });
+            assert.equal(
+              result,
+              path.join(path.resolve(directory), '/foo.ts')
+            );
+          });
         });
 
         describe('as a string', function() {


### PR DESCRIPTION
fix: https://github.com/dependents/node-filing-cabinet/issues/89

We have both TS and JS in the same project with `allowJs` typescript's `compillerOption`. `node-filing-cabinet` only looks up `.js` or `.jsx` on JS file but we expect to look up JS, `.ts` or `.tsx`.

This PR will make it solved. 