### PR TITLE
support webpack multiple configurations

### DIFF
--- a/index.js
+++ b/index.js
@@ -312,6 +312,9 @@ function resolveWebpackPath({dependency, filename, directory, webpackConfig}) {
     if (typeof loadedConfig === 'function') {
       loadedConfig = loadedConfig();
     }
+    if (Array.isArray(loadedConfig)) {
+      loadedConfig = loadedConfig[0];
+    }
   } catch (e) {
     debug('error loading the webpack config at ' + webpackConfig);
     debug(e.message);

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ console.log(result); // /absolute/path/to/somePartialPath
 * `ast`: (optional) the parsed AST for `filename`.
  * Useful optimization for avoiding a parse of filename
 * `config`: (optional) requirejs config for resolving aliased JavaScript modules
-* `webpackConfig`: (optional) webpack config for resolving aliased JavaScript modules
+* `webpackConfig`: (optional) webpack config for resolving aliased JavaScript modules. If exporting multiple configurations, the first configuration is used.
 * `nodeModulesConfig`: (optional) config for resolving entry file for node_modules. This value overrides the `main` attribute in the package.json file; used in conjunction with the [packageFilter](https://github.com/browserify/resolve#resolveid-opts-cb) of the `resolve` package.
 * `tsConfig`: (optional) path to a typescript configuration. Could also be an object representing a pre-parsed typescript config.
 * `noTypeDefinitions`: (optional) For typescript files, whether to prefer `*.js` over `*.d.ts`.

--- a/test/test.js
+++ b/test/test.js
@@ -943,6 +943,17 @@ describe('filing-cabinet', function() {
       assert.equal(resolved, expected);
     });
 
+    it('resolves a path using a first configuration', function() {
+      const resolved = cabinet({
+        partial: 'mod1',
+        filename: `${directory}/index.js`,
+        directory,
+        webpackConfig: `${directory}/webpack-multiple.config.js`
+      });
+      var expected = path.normalize(`${directory}/test/root1/mod1.js`);
+      assert.equal(resolved, expected);
+    });
+
     it('resolves files with a .jsx extension', function() {
       testResolution('./test/foo.jsx', `${directory}/test/foo.jsx`);
     });

--- a/webpack-multiple.config.js
+++ b/webpack-multiple.config.js
@@ -1,0 +1,14 @@
+module.exports = [
+  {
+    entry: "./index.js",
+    resolve: {
+      modulesDirectories: ['test/root1', 'node_modules'],
+    }
+  },
+  {
+    entry: "./index.js",
+    resolve: {
+      modulesDirectories: ['test/root2', 'node_modules'],
+    }
+  },
+];


### PR DESCRIPTION
support when webpack config is exported [multiple configurations](https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations).
it might be nice to select a configuration which one to use, but this PR does not add this option, it always uses the first one.