### PR TITLE
Fix: mixed ts+js with custom tsconfig.json paths

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -617,6 +617,31 @@ describe('filing-cabinet', function() {
               path.join(path.resolve(directory), '/foo.ts')
             );
           });
+
+          it('finds imports using custom import paths from javascript files with allowJs option', function() {
+            const filename = directory + '/bar.js';
+
+            const result = cabinet({
+              partial: '@shortcut/subimage.svg',
+              filename,
+              directory,
+              tsConfig: {
+                compilerOptions: {
+                  allowJs: true,
+                  moduleResolution: 'node',
+                  baseUrl: directory,
+                  paths: {
+                    '@shortcut/*': ['subdir/*'],
+                  }
+                }
+              }
+            });
+
+            assert.equal(
+              result,
+              path.join(path.resolve(directory), '../node_modules/image/npm-image.svg')
+            );
+          });
         });
 
         describe('as a string', function() {


### PR DESCRIPTION
Hello! This is a continuation of https://github.com/dependents/node-filing-cabinet/pull/91, which fixed *most* of the problem described. It doesn't quite handle one case: when the typescript project uses custom path prefixes via `compilerOptions.paths`.

This problem occurs with a tsconfig.json that looks like this:
```jsonc
// ./tsconfig.json
{
  "compilerOptions": {
    "module": "CommonJS", // important to set, madge defaults to AMD.
    "allowJs": true,
    "paths": { "@/*": ["src/at/*"] },
  }
}
```

and a project layout that looks like this:
```ts
// ./src/at/b/index.ts or ./src/at/b.ts
export const foo = 'bar';
```

```js
// ./src/a.js
import { foo } from '@/b';
console.log(foo);
```

The approach #91 takes is to allow the commonjs resolver utility to look for `.ts` files, and it makes sense for that to ignore any custom path behavior set by `tsconfig.json`.

The approach this PR takes is, if the user sets `allowJs: true`, we can assume they intend for their entire project to run through the typescript compiler. So we should likewise run .js files through the typescript engine for module resolution.

TODO:
- [ ] actually run tests and make sure this all works.