### PR TITLE
Support webpack config with TypeScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,11 +223,16 @@ function jsLookup(options) {
   }
 }
 
-function tsLookup({dependency, filename, tsConfig, tsConfigPath, noTypeDefinitions}) {
+function tsLookup({dependency, filename, directory, webpackConfig, tsConfig, tsConfigPath, noTypeDefinitions}) {
   debug('performing a typescript lookup');
 
   if (typeof tsConfig === 'string') {
     tsConfigPath = tsConfigPath || path.dirname(tsConfig);
+  }
+
+  if (!tsConfig && webpackConfig) {
+    debug('using webpack resolver for typescript');
+    return resolveWebpackPath({dependency, filename, directory, webpackConfig});
   }
 
   let compilerOptions = getCompilerOptionsFromTsConfig(tsConfig);

--- a/test/test.js
+++ b/test/test.js
@@ -518,6 +518,7 @@ describe('filing-cabinet', function() {
             assert.equal(result, path.join(directory, 'foo.ts'));
           });
         });
+
         describe(`when the typescript's path mapping is configured`, function() {
           it('should resolve the path', function() {
             const result = cabinet({
@@ -555,6 +556,23 @@ describe('filing-cabinet', function() {
           });
 
           assert.equal(result, path.join(directory, 'foo.ts'));
+        });
+      });
+
+      describe('when given a tsconfig and webpack config', function() {
+        it('resolves the module', function() {
+          const result = cabinet({
+            partial: './subdir',
+            filename: path.join(directory, 'check-nested.ts'),
+            directory,
+            tsConfig: path.join(directory, '.tsconfigExtending'),
+            webpackConfig: path.join(directory, 'webpack.config.js')
+          });
+
+          assert.equal(
+            result,
+            path.join(directory, 'subdir/index.tsx')
+          );
         });
       });
     });
@@ -829,6 +847,18 @@ describe('filing-cabinet', function() {
       it('still works', function() {
         testResolution('hgn!resolve', path.join(directory, 'node_modules/resolve/index.js'));
       });
+    });
+
+    it('resolves files with a .ts extension', function() {
+      const resolved = cabinet({
+        partial: 'R',
+        filename: path.join(directory, 'index.ts'),
+        directory,
+        webpackConfig: path.join(directory, 'webpack.config.js')
+      });
+
+      const expected = path.join(directory, 'node_modules/resolve/index.js');
+      assert.equal(resolved, expected);
     });
   });
 });

--- a/test/ts/webpack.config.js
+++ b/test/ts/webpack.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  entry: "./index.js"
+};


### PR DESCRIPTION
I'm using `node-dependency-tree` in typescript using webpack.

But, the `.ts` extension file cannot resolve the file specified in `resolve` in webpack config, because don't refer to webpack config.

So, I thought if webpack config is specified, how about changing it to use `resolveWebpackPath`?
But, There is a concern that this fix will result in breaking changes.