### PR TITLE
Fix resolving js imports that have same-named ".d.ts" from ts with 'noTypeDefinitions' set to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,7 +252,8 @@ function tsLookup({dependency, filename, directory, webpackConfig, tsConfig, tsC
   if (namedModule.resolvedModule) {
     result = namedModule.resolvedModule.resolvedFileName;
     if (namedModule.resolvedModule.extension === '.d.ts' && noTypeDefinitions) {
-      result = ts.resolveJSModule(dependency, path.dirname(filename), host) || result;
+      const resolvedFileNameWithoutExtension = result.replace(namedModule.resolvedModule.extension, '');
+      result = ts.resolveJSModule(resolvedFileNameWithoutExtension, path.dirname(filename), host) || result;
     }
   } else {
     const suffix = '.d.ts';

--- a/test/test.js
+++ b/test/test.js
@@ -323,6 +323,29 @@ describe('filing-cabinet', function() {
           );
         });
 
+        it('resolves the import of a file with type-definition to the JS file using custom import paths', function() {
+          const filename = path.join(directory, './index.ts');
+
+          const result = cabinet({
+            partial: '@test/withTypeDef',
+            filename,
+            directory,
+            tsConfig: {
+              compilerOptions: {
+                allowJs: true,
+                moduleResolution: 'node',
+                baseUrl: directory,
+                paths: {
+                  '@test/*': ['*'],
+                }
+              }
+            },
+            noTypeDefinitions: true,
+          });
+
+          assert.equal(result, path.join(directory, 'withTypeDef.js'));
+        });
+
         it('still returns the .d.ts file if no JS file is found', function() {
           const filename = path.join(directory, '/index.ts');
 


### PR DESCRIPTION
**Reason:**
If ```.d.ts``` exists, ```ts``` resolve import as the path to the type-definition file by default (instead of the js file).
But if we set the ```noTypeDefinitions``` flag to true, 
we pass the unresolved import path to the ```ts.resolveJSModule```.

And if we have a type alias:
```
// tsconfig.json
{
  "compilerOptions": {
    "paths": {
      "@test/*": ["*"]
    }
  }
}
```
our unresolved import looks like
```
@test/foo
```
instead of
```
<path_to_directory>/foo
```
Therefore ```ts``` cannot resolve this import and fails with an error.

**Solution:**
Pass to the ```ts.resolveJSModule``` resolved path of the import without extension.

Relates to: https://github.com/dependents/node-filing-cabinet/issues/112