### PR TITLE
fix: webpack roots

### DIFF
--- a/index.js
+++ b/index.js
@@ -416,11 +416,22 @@ function resolveWebpackPath({ dependency, filename, directory, webpackConfig }) 
 
   const resolveConfig = { ...loadedConfig.resolve };
 
-  if (!resolveConfig.modules && (resolveConfig.root || resolveConfig.modulesDirectories)) {
+  if (!resolveConfig.modules && (resolveConfig.root || resolveConfig.roots || resolveConfig.modulesDirectories)) {
     resolveConfig.modules = [];
 
-    if (resolveConfig.root) {
+    // `resolve.root` is a string, maybe used in webpack 1.x.
+    // here: https://github.com/webpack/webpack/issues/472#issuecomment-166946925
+    if (typeof resolveConfig.root === 'string') {
+      resolveConfig.modules = [...resolveConfig.modules, resolveConfig.root];
+    }
+
+    if (Array.isArray(resolveConfig.root)) {
       resolveConfig.modules = [...resolveConfig.modules, ...resolveConfig.root];
+    }
+
+    // https://webpack.js.org/configuration/resolve/#resolveroots
+    if (Array.isArray(resolveConfig.roots)) {
+      resolveConfig.modules = [...resolveConfig.modules, ...resolveConfig.roots];
     }
 
     if (resolveConfig.modulesDirectories) {

--- a/test/fixtures/webpack/webpack-root-string.config.js
+++ b/test/fixtures/webpack/webpack-root-string.config.js
@@ -1,0 +1,8 @@
+var path = require('path');
+
+module.exports = {
+  entry: "./index.js",
+  resolve: {
+    root: path.resolve(__dirname, './test/root2'),
+  }
+};

--- a/test/fixtures/webpack/webpack-root.config.js
+++ b/test/fixtures/webpack/webpack-root.config.js
@@ -4,7 +4,7 @@ module.exports = {
   entry: "./index.js",
   resolve: {
     modulesDirectories: ['test/root1', 'node_modules'],
-    root: [
+    roots: [
         path.resolve(__dirname, './test/root2'),
         path.resolve(__dirname, './node_modules')
     ]

--- a/test/fixtures/webpack/webpack-roots.config.js
+++ b/test/fixtures/webpack/webpack-roots.config.js
@@ -3,8 +3,7 @@ var path = require('path');
 module.exports = {
   entry: "./index.js",
   resolve: {
-    modulesDirectories: ['test/root1', 'node_modules'],
-    root: [
+    roots: [
         path.resolve(__dirname, './test/root2'),
         path.resolve(__dirname, './node_modules')
     ]

--- a/test/test.js
+++ b/test/test.js
@@ -731,7 +731,7 @@ describe('filing-cabinet', () => {
       assert.equal(result, expected);
     });
 
-    it('resolves a path using resolve.root', () => {
+    it('resolves a path using resolve.root that value is array', () => {
       const result = cabinet({
         partial: 'mod1',
         filename: path.join(directory, 'index.js'),
@@ -742,7 +742,40 @@ describe('filing-cabinet', () => {
       assert.equal(result, expected);
     });
 
+    it('resolves a path using resolve.root that value is string', () => {
+      const result = cabinet({
+        partial: 'mod2',
+        filename: path.join(directory, 'index.js'),
+        directory,
+        webpackConfig: path.join(directory, 'webpack-root-string.config.js')
+      });
+      const expected = path.join(directory, 'test/root2/mod2.js');
+      assert.equal(result, expected);
+    });
+
+    it('resolves a path using resolve.roots', () => {
+      const result = cabinet({
+        partial: 'mod2',
+        filename: path.join(directory, 'index.js'),
+        directory,
+        webpackConfig: path.join(directory, 'webpack-roots.config.js')
+      });
+      const expected = path.join(directory, 'test/root2/mod2.js');
+      assert.equal(result, expected);
+    });
+
     it('resolves npm module when using resolve.root', () => {
+      const result = cabinet({
+        partial: 'resolve',
+        filename: path.join(directory, 'index.js'),
+        directory,
+        webpackConfig: path.join(directory, 'webpack-root.config.js')
+      });
+      const expected = path.join(directory, 'node_modules/resolve/index.js');
+      assert.equal(result, expected);
+    });
+
+    it('resolves npm module when using resolve.roots', () => {
       const result = cabinet({
         partial: 'resolve',
         filename: path.join(directory, 'index.js'),


### PR DESCRIPTION
1. `resolve.root` maybe a string, used in webpack 1.x.
more detail here: https://github.com/webpack/webpack/issues/472#issuecomment-166946925

2. `resolve.roots` is used in latest webpack.
webpack docs: https://webpack.js.org/configuration/resolve/#resolveroots