### PR TITLE
fix: handle `undefined` `failedLookupLocations`

### DIFF
--- a/index.js
+++ b/index.js
@@ -260,7 +260,7 @@ function tsLookup({ dependency, filename, directory, webpackConfig, tsConfig, ts
     }
   } else {
     const suffix = '.d.ts';
-    const lookUpLocations = namedModule.failedLookupLocations
+    const lookUpLocations = (namedModule.failedLookupLocations ?? [])
       .filter(string => string.endsWith(suffix))
       .map(string => string.substr(0, string.length - suffix.length));
 

--- a/test/test.js
+++ b/test/test.js
@@ -398,6 +398,16 @@ describe('filing-cabinet', () => {
             assert.equal(result, expected);
           });
 
+          it('finds imports of non-existent typescript imports', () => {
+            const filename = path.join(directory, '/index.ts');
+            const result = cabinet({
+              partial: 'virtual:test-virtual',
+              filename,
+              directory
+            });
+            assert.equal(result, '');
+          });
+
           it('finds imports of non-typescript files using custom import paths', () => {
             const filename = path.join(directory, '/index.ts');
             const result = cabinet({


### PR DESCRIPTION
This primarily happens with my vite projects that import a virtual module.

The module in question is: virtual:pwa-register, which causes failedLookupLocations to be undefined and blows up on the filter call.

This prevents me from scanning my projects for circular dependencies.

Fixes #125 