### PR TITLE
Add getLookup() API to allow composing custom lookup from internal lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,15 @@ module.exports = function(options = {}) {
 module.exports.supportedFileExtensions = Object.keys(defaultLookups);
 
 /**
+ * Get a lookup resolver for a file extension
+ *
+ * @param  {String} extension - The file extension whose resolver should be removed
+ */
+module.exports.getLookup = function(extension) {
+  return defaultLookups[extension];
+};
+
+/**
  * Register a custom lookup resolver for a file extension
  *
  * @param  {String} extension - The file extension that should use the resolver

--- a/index.js
+++ b/index.js
@@ -78,9 +78,9 @@ module.exports = function(options = {}) {
 module.exports.supportedFileExtensions = Object.keys(defaultLookups);
 
 /**
- * Get a lookup resolver for a file extension
+ * Get the lookup resolver for a given file extension
  *
- * @param  {String} extension - The file extension whose resolver should be removed
+ * @param {string} extension - The file extension whose resolver should be retrieved.
  */
 module.exports.getLookup = function(extension) {
   return defaultLookups[extension];

--- a/test/test.js
+++ b/test/test.js
@@ -735,19 +735,16 @@ describe('filing-cabinet', () => {
   });
 
   describe('.getLookup', () => {
-    const directory = path.join(__dirname, 'fixtures/ts');
-
     it('returns a lookup by extension', () => {
       const tsLookup = cabinet.getLookup('.ts');
       cabinet.register('.customTs', tsLookup);
 
-      const filename = path.join(directory, 'index.customTs');
       const result = cabinet({
         partial: './foo',
-        filename,
-        directory
+        filename: fixtures('ts/index.customTs'),
+        directory: fixtures('ts/')
       });
-      const expected = path.join(directory, 'foo.ts');
+      const expected = fixtures('ts/foo.ts');
       assert.equal(result, expected);
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -734,6 +734,29 @@ describe('filing-cabinet', () => {
     });
   });
 
+  describe('.getLookup', () => {
+    const directory = path.join(__dirname, 'fixtures/ts');
+
+    it('returns a lookup by extension', () => {
+      const tsLookup = cabinet.getLookup('.ts');
+      cabinet.register('.customTs', tsLookup);
+
+      const filename = path.join(directory, 'index.customTs');
+      const result = cabinet({
+        partial: './foo',
+        filename,
+        directory
+      });
+      const expected = path.join(directory, 'foo.ts');
+      assert.equal(result, expected);
+    });
+
+    it('returns undefined when no lookup matches extension', () => {
+      const unknownLookup = cabinet.getLookup('.unknown');
+      assert.equal(unknownLookup, undefined);
+    });
+  });
+
   describe('.register', () => {
     it('registers a custom resolver for a given extension', () => {
       const stub = sinon.stub().returns('foo.foobar');


### PR DESCRIPTION
Proposing to add a `getLookup` API. For my use case, I have some proprietary paths in a stylesheet that are not handled by existing lookups. While I can register a custom lookup to resolve these proprietary paths, I only need to handle certain of those paths, and want to defer the rest to existing lookups. Currently, the `tsLookup` and some others aren't exported - rather than exporting those, I thought this solution could be more flexible and future-proof if new internal lookups are added.

If this looks desirable, I can do another pass to update docs. Thanks!