### PR TITLE
Cache the webpack resolver per `webpackConfig` path

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ module.exports._getJSType = function(options = {}) {
   return getModuleType.sync(options.filename);
 };
 
+const webpackResolverByConfig = new Map();
 let compilerHost;
 
 function getCompilerHost() {
@@ -471,53 +472,61 @@ function resolveWebpackPath({ dependency, filename, directory, webpackConfig }) 
   webpackResolve ||= require('enhanced-resolve');
 
   webpackConfig = path.resolve(webpackConfig);
-  let loadedConfig;
+  let resolver = webpackResolverByConfig.get(webpackConfig);
+  let resolveConfig;
 
-  try {
-    loadedConfig = require(webpackConfig);
+  if (!resolver) {
+    let loadedConfig;
 
-    if (typeof loadedConfig === 'function') {
-      loadedConfig = loadedConfig();
+    try {
+      loadedConfig = require(webpackConfig);
+
+      if (typeof loadedConfig === 'function') {
+        loadedConfig = loadedConfig();
+      }
+
+      if (Array.isArray(loadedConfig)) {
+        loadedConfig = loadedConfig[0];
+      }
+    } catch (error) {
+      debug(`error loading the webpack config at ${webpackConfig}:\n${error.stack}`);
+      return '';
     }
 
-    if (Array.isArray(loadedConfig)) {
-      loadedConfig = loadedConfig[0];
+    resolveConfig = { ...loadedConfig.resolve };
+
+    if (!resolveConfig.modules && (resolveConfig.root || resolveConfig.roots || resolveConfig.modulesDirectories)) {
+      resolveConfig.modules = [];
+
+      // `resolve.root` is a string, it may be used in webpack 1.x.
+      // here: https://github.com/webpack/webpack/issues/472#issuecomment-166946925
+      if (typeof resolveConfig.root === 'string') {
+        resolveConfig.modules = [...resolveConfig.modules, resolveConfig.root];
+      }
+
+      if (Array.isArray(resolveConfig.root)) {
+        resolveConfig.modules = [...resolveConfig.modules, ...resolveConfig.root];
+      }
+
+      // https://webpack.js.org/configuration/resolve/#resolveroots
+      if (Array.isArray(resolveConfig.roots)) {
+        resolveConfig.modules = [...resolveConfig.modules, ...resolveConfig.roots];
+      }
+
+      if (resolveConfig.modulesDirectories) {
+        resolveConfig.modules = [
+          ...resolveConfig.modules,
+          ...resolveConfig.modulesDirectories
+        ];
+      }
     }
-  } catch (error) {
-    debug(`error loading the webpack config at ${webpackConfig}:\n${error.stack}`);
-    return '';
   }
 
-  const resolveConfig = { ...loadedConfig.resolve };
-
-  if (!resolveConfig.modules && (resolveConfig.root || resolveConfig.roots || resolveConfig.modulesDirectories)) {
-    resolveConfig.modules = [];
-
-    // `resolve.root` is a string, it may be used in webpack 1.x.
-    // here: https://github.com/webpack/webpack/issues/472#issuecomment-166946925
-    if (typeof resolveConfig.root === 'string') {
-      resolveConfig.modules = [...resolveConfig.modules, resolveConfig.root];
-    }
-
-    if (Array.isArray(resolveConfig.root)) {
-      resolveConfig.modules = [...resolveConfig.modules, ...resolveConfig.root];
-    }
-
-    // https://webpack.js.org/configuration/resolve/#resolveroots
-    if (Array.isArray(resolveConfig.roots)) {
-      resolveConfig.modules = [...resolveConfig.modules, ...resolveConfig.roots];
-    }
-
-    if (resolveConfig.modulesDirectories) {
-      resolveConfig.modules = [
-        ...resolveConfig.modules,
-        ...resolveConfig.modulesDirectories
-      ];
-    }
-  }
-
   try {
-    const resolver = webpackResolve.create.sync(resolveConfig);
+    if (!resolver) {
+      resolver = webpackResolve.create.sync(resolveConfig);
+      webpackResolverByConfig.set(webpackConfig, resolver);
+    }
 
     // We don't care about what the loader resolves the dependency to
     // we only want the path of the resolved file

--- a/test/webpack.test.js
+++ b/test/webpack.test.js
@@ -197,4 +197,17 @@ describe('webpack', () => {
 
     assert.equal(result, '');
   });
+
+  it('returns the same result on repeated lookups against the same webpack config', () => {
+    const options = {
+      partial: 'R',
+      filename: path.join(directory, 'index.js'),
+      directory,
+      webpackConfig: path.join(directory, 'webpack.config.js')
+    };
+    const expected = path.join(directory, 'node_modules/resolve/index.js');
+
+    assert.equal(cabinet(options), expected);
+    assert.equal(cabinet(options), expected);
+  });
 });


### PR DESCRIPTION
`enhanced-resolve`'s `create.sync` is rebuilt on every call, even for repeated lookups against the same webpack config. Cache resolvers by the resolved (absolute) webpackConfig path so subsequent lookups skip both the config require/normalize step and the resolver construction.

Fixes #96.

Non-whitespace diff: https://github.com/dependents/node-filing-cabinet/pull/160/changes?w=1