### PR TITLE
fix: resolve nested node_modules from the file's directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -421,7 +421,7 @@ function commonJSLookup(options) {
 
     result = resolve.sync(dependency, {
       extensions,
-      basedir: directory,
+      basedir: path.dirname(filename),
       packageFilter: packageFilterOption,
       // Add fileDir to resolve index.js files in that dir
       moduleDirectory: ['node_modules', directory]

--- a/test/test.js
+++ b/test/test.js
@@ -223,6 +223,16 @@ describe('filing-cabinet', () => {
         assert.equal(result, expected);
       });
 
+      it('resolves a nested module when directory is an ancestor of the file', () => {
+        const result = cabinet({
+          partial: 'lodash.assign',
+          filename: fixtures('js/node_modules/nested/index.js'),
+          directory: fixtures('js/')
+        });
+        const expected = fixtures('js/node_modules/nested/node_modules/lodash.assign/index.js');
+        assert.equal(result, expected);
+      });
+
       it('resolves to the index.js file of a directory', () => {
         const result = cabinet({
           partial: './subdir',


### PR DESCRIPTION
commonJSLookup was passing `basedir: directory` to `resolve.sync`, anchoring the module walk to the project root. This caused a file deep inside `node_modules/foo/` to resolve a dependency to the top-level copy rather than the closer `foo/node_modules/` copy.

Fix: use `basedir: path.dirname(filename)` so the walk starts at the requiring file's directory, matching Node's native algorithm. The existing `moduleDirectory: ['node_modules', directory]` option already ensures that bare names resolvable from the project root (e.g. a `subdir/` sibling) continue to work regardless of `basedir`.

Fixes #104.