### PR TITLE
Handle webpack configs that export a Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -479,6 +479,12 @@ function resolveWebpackPath({ dependency, filename, directory, webpackConfig }) 
         loadedConfig = loadedConfig();
       }
 
+      // Webpack 2+ allows Promise exports; we're synchronous so bail out gracefully.
+      if (loadedConfig && typeof loadedConfig.then === 'function') {
+        debug(`webpack config at ${webpackConfig} exports a Promise, which is not supported in synchronous mode`);
+        return '';
+      }
+
       if (Array.isArray(loadedConfig)) {
         loadedConfig = loadedConfig[0];
       }

--- a/test/fixtures/webpack/webpack-promise.config.js
+++ b/test/fixtures/webpack/webpack-promise.config.js
@@ -1,0 +1,8 @@
+module.exports = Promise.resolve({
+  entry: './index.js',
+  resolve: {
+    alias: {
+      R: './node_modules/resolve'
+    }
+  }
+});

--- a/test/webpack.test.js
+++ b/test/webpack.test.js
@@ -174,6 +174,17 @@ describe('webpack', () => {
     assert.equal(result, expected);
   });
 
+  it('returns empty string when the webpack config exports a Promise', () => {
+    const result = cabinet({
+      partial: './test/ast',
+      filename: path.join(directory, 'index.js'),
+      directory,
+      webpackConfig: path.join(directory, 'webpack-promise.config.js')
+    });
+
+    assert.equal(result, '');
+  });
+
   it('returns empty string when the webpack config cannot be loaded', () => {
     const result = cabinet({
       partial: './foo',


### PR DESCRIPTION
Webpack 2+ supports Promise-based config exports, but resolveWebpackPath is synchronous so it cannot await them. Without this guard, a Promise config silently drops all resolve options (aliases, modules, etc.) because spreading a Promise object yields {}.

Closes #82.